### PR TITLE
Rounded Button Default & Label Buttons

### DIFF
--- a/resources/scss/patterns/_buttons.scss
+++ b/resources/scss/patterns/_buttons.scss
@@ -255,3 +255,8 @@ dialog[role="navigation"] a[disabled], dialog[role="navigation"] a.disabled {
 a:is([role="button"],[role="menuitem"],[role="tab"],.btn), dialog[role="navigation"] a {
   text-decoration: none;
 }
+
+// Rounded corners, unless menuitem, tab, drawer
+button:not([role="menuitem"]):not([role="tab"]), a[role="button"] {
+  --border-radius: calc(var(--font-size) + var(--input-padding-x));
+}

--- a/resources/scss/patterns/_buttons.scss
+++ b/resources/scss/patterns/_buttons.scss
@@ -239,6 +239,7 @@ button {
 button,
 input:is([type="button"],[type="submit"],[type="reset"]),
 a:is([role="button"],[role="menuitem"],[role="tab"],.btn),
+label:is([role="button"]),
 dialog[role="navigation"] a {
   @extend %button
 }
@@ -257,6 +258,6 @@ a:is([role="button"],[role="menuitem"],[role="tab"],.btn), dialog[role="navigati
 }
 
 // Rounded corners, unless menuitem, tab, drawer
-button:not([role="menuitem"]):not([role="tab"]), a[role="button"] {
+button:not([role="menuitem"]):not([role="tab"]), a:is([role="button"]), label:is([role="button"]) {
   --border-radius: calc(var(--font-size) + var(--input-padding-x));
 }


### PR DESCRIPTION
* Makes buttons have rounded corners by default to distinguish from other UI elements.
* Allows labels to be buttons if [role="button"] is specified.