### PR TITLE
Improve WebKit Font Legibility

### DIFF
--- a/resources/scss/utility/_reset.scss
+++ b/resources/scss/utility/_reset.scss
@@ -11,6 +11,12 @@ html {
   //noinspection ALL
   font-size: var(--font-size-root);
   text-rendering: optimizeLegibility;
+}
+
+// Add stroke on webkit, only if not HiDPI display
+@media only screen and (-webkit-max-device-pixel-ratio: 1),
+only screen and (max-device-pixel-ratio: 1) ,
+only screen and (max-resolution: 1dppx) {
   -webkit-text-stroke-width: 0.20px;
 }
 

--- a/resources/scss/utility/_reset.scss
+++ b/resources/scss/utility/_reset.scss
@@ -17,7 +17,9 @@ html {
 @media only screen and (-webkit-max-device-pixel-ratio: 1),
 only screen and (max-device-pixel-ratio: 1) ,
 only screen and (max-resolution: 1dppx) {
-  -webkit-text-stroke-width: 0.20px;
+  html {
+    -webkit-text-stroke-width: 0.20px;
+  }
 }
 
 body {


### PR DESCRIPTION
Fixes the appearance of fonts on Retina/HiDPI screens, by limit the stroke used to improve readability on low resolution screens to low resolution screens.