### PR TITLE
Do not override form field colors in _groups.scss

### DIFF
--- a/resources/scss/forms/_base.scss
+++ b/resources/scss/forms/_base.scss
@@ -53,9 +53,10 @@ input, textarea, select, form .wrapper {
   --color-value-disabled: rgba(var(--theme-on-bg-alt-red), var(--theme-on-bg-alt-green), var(--theme-on-bg-alt-blue), var(--opacity-disabled));
   --color-placeholder-disabled: rgba(var(--theme-on-bg-alt-red), var(--theme-on-bg-alt-green), var(--theme-on-bg-alt-blue), var(--opacity-disabled));
   --color-outline-disabled: rgba(var(--theme-outline-red), var(--theme-outline-green), var(--theme-outline-blue), var(--opacity-disabled-bg));
-  &:focus {
-    --color-outline: var(--theme-color);
-  }
+}
+
+input:focus, textarea:focus, select:focus, form .wrapper:focus-within {
+  --color-outline: var(--theme-color);
 }
 
 label {

--- a/resources/scss/forms/_groups.scss
+++ b/resources/scss/forms/_groups.scss
@@ -50,16 +50,7 @@ form > section, form > fieldset {
 }
 
 form .field {
-  > input, > select, > textarea, > .wrapper {
-    --color-value: var(--theme-on-bg);
-    --color-bg: var(--theme-bg-alt);
-    --color-text: var(--theme-on-alt);
-    --color-label: var(--theme-on-bg-alt);
-    --color-icon: var(--theme-on-bg-alt);
-    --color-outline: var(--theme-outline);
-  }
   > input:focus, > select:focus, > textarea:focus, > .wrapper:focus-within {
-    --color-outline: var(--theme-color);
     & ~ label {
       --color-label: var(--theme-color);
     }


### PR DESCRIPTION
Prevents override of CSS color variables in field group CSS, which is preventing disabled and readonly colors from working properly.